### PR TITLE
Bump java-dogstatsd-client version to 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>com.datadoghq</groupId>
                 <artifactId>java-dogstatsd-client</artifactId>
-                <version>2.1.1</version>
+                <version>2.3</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
This version includes a bug fix where packets get dropped due to UDP packets being too large, see https://github.com/DataDog/java-dogstatsd-client/pull/17.